### PR TITLE
Keep proper data type for JSON arrays between conversions. 

### DIFF
--- a/src/main/java/net/sf/json/xml/XMLSerializer.java
+++ b/src/main/java/net/sf/json/xml/XMLSerializer.java
@@ -828,6 +828,7 @@ public class XMLSerializer {
             type = defaultType;
          }
       }
+      
       return type;
    }
 
@@ -1271,10 +1272,10 @@ public class XMLSerializer {
             params = StringUtils.split( paramsAttribute.getValue(), "," );
             jsonArray.element( new JSONFunction( params, text ) );
             return;
-         }else{
+         }/*else{
             jsonArray.element( simplifyValue( null, processElement( element, type ) ) );
             return;
-         }
+         }*/
       }
 
       boolean classProcessed = false;
@@ -1335,7 +1336,6 @@ public class XMLSerializer {
       String clazz = getClass( element );
       String type = getType( element );
       type = (type == null) ? defaultType : type;
-
 
       String key = removeNamespacePrefix( element.getQualifiedName() );
       if( hasNamespaces( element ) && !skipNamespaces ){


### PR DESCRIPTION
If you convert a JSON array into XML and back to JSON, every data types in the array will be converted to string.

ie., {"k": [34, true, "val"]} -> xml -> json => {"k": ["34", "true", "val"]}

That's fixed in this commit as is done for JSONObjects.