### PR TITLE
Keep proper data type for JSON arrays between conversions. & Fixed conversions for nested JSON arrays and single element Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 *.iws
 .idea
 out
+/.nb-gradle/

--- a/src/main/java/org/kordamp/json/xml/XMLSerializer.java
+++ b/src/main/java/org/kordamp/json/xml/XMLSerializer.java
@@ -1368,10 +1368,10 @@ public class XMLSerializer {
                 params = StringUtils.split(paramsAttribute.getValue(), ",");
                 jsonArray.element(new JSONFunction(params, text));
                 return;
-            } else {
+            }/* else {
                 jsonArray.element(simplifyValue(null, processElement(element, type)));
                 return;
-            }
+            }*/
         }
 
         boolean classProcessed = false;

--- a/src/main/java/org/kordamp/json/xml/XMLSerializer.java
+++ b/src/main/java/org/kordamp/json/xml/XMLSerializer.java
@@ -522,6 +522,7 @@ public class XMLSerializer {
         try {
             Document doc = new Builder().build(new StringReader(xml));
             Element root = doc.getRootElement();
+            log.info("[ " + root.getLocalName() + " " + isNullObject(root) + " " + isArray(root, true));
             if (isNullObject(root)) {
                 return JSONNull.getInstance();
             }
@@ -830,7 +831,7 @@ public class XMLSerializer {
                 }
             }
         }
-
+        
         String childName = elements.get(0)
             .getQualifiedName();
         for (int i = 1; i < elementCount; i++) {
@@ -929,7 +930,7 @@ public class XMLSerializer {
             && (element.getAttribute(addJsonPrefix("class")) != null && element.getAttribute(addJsonPrefix("type")) != null)) {
             isArray = checkChildElements(element, isTopLevel);
         }
-
+        
         if (isArray) {
             // check namespace
             for (int j = 0; j < element.getNamespaceDeclarationCount(); j++) {
@@ -941,6 +942,11 @@ public class XMLSerializer {
             }
         }
 
+        if(!isArray && isTopLevel && !isForceTopLevelObject() 
+            && element.getQualifiedName().equalsIgnoreCase(getArrayName())){
+            isArray = true;
+        }
+        
         return isArray;
     }
 
@@ -974,6 +980,12 @@ public class XMLSerializer {
                 && (element.getAttribute(addJsonPrefix("class")) != null && element.getAttribute(addJsonPrefix("type")) != null)) {
                 return true;
             }
+//            String clazz = getClass(element);
+//            if(element.getAttribute(addJsonPrefix("class")) != null && 
+//                    (clazz.equalsIgnoreCase(JSONTypes.OBJECT) || 
+//                        clazz.equalsIgnoreCase(JSONTypes.ARRAY))){
+//                return false;
+//            }
         }
         if (skipWhitespace && element.getChildCount() == 1 && element.getChild(0) instanceof Text) {
             return true;

--- a/src/main/java/org/kordamp/json/xml/XMLSerializer.java
+++ b/src/main/java/org/kordamp/json/xml/XMLSerializer.java
@@ -980,12 +980,6 @@ public class XMLSerializer {
                 && (element.getAttribute(addJsonPrefix("class")) != null && element.getAttribute(addJsonPrefix("type")) != null)) {
                 return true;
             }
-//            String clazz = getClass(element);
-//            if(element.getAttribute(addJsonPrefix("class")) != null && 
-//                    (clazz.equalsIgnoreCase(JSONTypes.OBJECT) || 
-//                        clazz.equalsIgnoreCase(JSONTypes.ARRAY))){
-//                return false;
-//            }
         }
         if (skipWhitespace && element.getChildCount() == 1 && element.getChild(0) instanceof Text) {
             return true;

--- a/src/test/java/org/kordamp/json/xml/TestXMLSerializer_reads.java
+++ b/src/test/java/org/kordamp/json/xml/TestXMLSerializer_reads.java
@@ -309,14 +309,28 @@ public class TestXMLSerializer_reads extends TestCase {
         JSONObject expected = JSONObject.fromObject("{name:\"json\",nested:{id:1}}");
         Assertions.assertEquals(expected, actual);
     }
+    
+    public void testReadNestedArray(){
+        String xml = "<a> <e class=\"array\"> <e type=\"string\">values</e> <e type=\"number\">1</e> </e> </a>";
+        JSON actual = (JSONArray) xmlSerializer.read(xml);
+        JSON expected = JSONArray.fromObject("[[\"values\", 1]]");
+        Assertions.assertEquals(expected, actual);
+    }
 
+    public void testReadSingleElementArray(){
+        String xml = "<a> <e type=\"string\">val</e> </a>";
+        JSON actual = xmlSerializer.read(xml);
+        JSON expected = JSONArray.fromObject("[\"val\"]");
+        Assertions.assertEquals(expected, actual);
+    }
+    
     public void testReadNumberArray_withDefaultType() {
         String xml = "<a type=\"number\"><e>1.1</e><e>2.2</e><e>3</e></a>";
         JSON actual = xmlSerializer.read(xml);
         JSON expected = JSONArray.fromObject("[1.1,2.2,3]");
         Assertions.assertEquals(expected, actual);
     }
-
+ 
     public void testReadNumberArray_withoutDefaultType() {
         String xml = "<a><e type=\"number\">1.1</e><e type=\"number\">2.2</e><e type=\"number\">3</e></a>";
         JSON actual = xmlSerializer.read(xml);


### PR DESCRIPTION
If you convert a JSON array into XML and back to JSON, every data types in the array will be converted to string.

ie., `{"k": [34, true, "val"]}` -> xml -> json => `{"k": ["34", "true", "val"]}`

That's fixed in this commit as is done for JSONObjects.

Second commit does proper conversions for following cases (multi array nesting is now possible):

`[['val', 32]]` -> xml -> json => `[['val', 32]]`
`[32]` -> xml -> json => `[32]`
