### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     groovy 'org.codehaus.groovy:groovy-all:1.8.10'
 	compile 'junit:junit:3.8.2',
 	        'commons-beanutils:commons-beanutils:1.8.0',
-	        'commons-collections:commons-collections:3.2.1',
+	        'commons-collections:commons-collections:3.2.2',
 	        'commons-lang:commons-lang:2.5',
 	compile('commons-logging:commons-logging:1.1.1') {
 		exclude(module: 'log4j')


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/