### PR TITLE
Prevent conversion of string properties to JSONArrays or JSONObjects …

### DIFF
--- a/src/main/java/net/sf/json/JSONSerializer.java
+++ b/src/main/java/net/sf/json/JSONSerializer.java
@@ -103,6 +103,8 @@ public class JSONSerializer {
          json = toJSON( (String) object, jsonConfig );
       }else if( JSONUtils.isArray( object ) ){
          json = JSONArray.fromObject( object, jsonConfig );
+      }else if( object instanceof JSONObject){
+         json = (JSONObject)object;
       }else{
          try{
             json = JSONObject.fromObject( object, jsonConfig );

--- a/src/test/java/net/sf/json/TestJSONObject.java
+++ b/src/test/java/net/sf/json/TestJSONObject.java
@@ -376,6 +376,16 @@ public class TestJSONObject extends TestCase {
             jsonObject.getJSONObject( "bean" ) );
    }
 
+   public void testElement_Object_nested() {
+      JSONObject jsonObject1 = new JSONObject();
+      jsonObject1.element( "str", "\"[]\"" );
+      Assertions.assertTrue(jsonObject1.get( "str" ) instanceof String);
+
+      JSONObject jsonObject2 = new JSONObject();
+      jsonObject2.element( "obj", jsonObject1);
+      Assertions.assertTrue(jsonObject2.getJSONObject( "obj" ).get( "str" ) instanceof String);
+   }
+
    public void testElement_String() {
       JSONObject jsonObject = new JSONObject();
       jsonObject.element( "str", "json" );


### PR DESCRIPTION
…when a JSONObject is nested within another JSON value.

String properties of JSONObjects that start with "[" and end with "]" should not be converted to arrays when the JSONObject is added to another JSONObject.
Fixed by not serializing and then deserializing JSONObjects when converting them to JSON.

Fixes https://github.com/aalmiray/Json-lib/issues/44