### PR TITLE
fix adoc table style

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,5 +12,5 @@ image:http://img.shields.io/badge/download-latest-bb00bb.svg[link="https://bintr
 
 JSON-lib is a java library for transforming beans, maps, collections, java arrays and XML to JSON and back again to beans and DynaBeans.
 
-Refer to the link:http://aalmiray.github.io/json-lib/[project guide, window="_blank"] for
+Refer to the link:https://github.com/aalmiray/Json-lib/[project guide, window="_blank"] for
 further information on configuration and usage.

--- a/README.adoc
+++ b/README.adoc
@@ -12,5 +12,5 @@ image:http://img.shields.io/badge/download-latest-bb00bb.svg[link="https://bintr
 
 JSON-lib is a java library for transforming beans, maps, collections, java arrays and XML to JSON and back again to beans and DynaBeans.
 
-Refer to the link:https://github.com/aalmiray/Json-lib/[project guide, window="_blank"] for
+Refer to the link:http://aalmiray.github.io/json-lib/[project guide, window="_blank"] for
 further information on configuration and usage.

--- a/subprojects/guide/src/docs/asciidoc/usage.adoc
+++ b/subprojects/guide/src/docs/asciidoc/usage.adoc
@@ -206,7 +206,7 @@ with '@' will be treated as an attribute, any property named '#text' will be tre
 
 Please review the javadoc for XMLSerializer to know more about the configurable options.
 
-[cols="l,l"]
+[cols="1,1"]
 |===
 |*Code* | *XML output*
 
@@ -246,7 +246,7 @@ JSONFunction needs an additional parameter that specifies that function's params
 All xml attributes will have the prefix '@' and text nodes will have the property name '#text'. XMLSerializer supports
 the rules outlined at http://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html[Converting Between XML and JSON]
 
-[cols="l,l"]
+[cols="1,1"]
 |===
 |*XML input* | *Code*
 


### PR DESCRIPTION
correct misspelling: change [cols="l,l"] to [cols="1,1"].
or the sign of `*` in `*Code*` will show in the title of table.