### PR TITLE
make Travis CI pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 script: ./gradlew clean build jacocoTestReport
-jdk: oraclejdk7
+jdk: openjdk8
 env: TERM=dumb
 after_success: ./gradlew jacocoRootReport coveralls


### PR DESCRIPTION
Change the jkd version to `openjdk8` will make the Travis CI pass.